### PR TITLE
fix template type for script tag

### DIFF
--- a/HTML-extended.tmLanguage
+++ b/HTML-extended.tmLanguage
@@ -305,7 +305,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:script))\b(?![^&gt;]*/&gt;)(?!.*type=["']text/(?:temp‌​late|html)['"])</string>
+			<string>(?:^\s+)?(&lt;)((?i:script))\b(?![^&gt;]*/&gt;)(?!.*type=["']text/(?:template|html)['"])</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/HTML-extended.tmLanguage
+++ b/HTML-extended.tmLanguage
@@ -305,7 +305,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:script))\b(?![^&gt;]*/&gt;)(?!.*type=["']text/(?:template|html)['"])</string>
+			<string>(?:^\s+)?(&lt;)((?i:script))\b(?![^&gt;]*/&gt;)(?!.*type=["']text/(?:template|ng-template|html)['"])</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
- There are two unicode characters in "template" string:
  
  ``` sh
  00000000: 7465 6d70 e280 8ce2 808b 6c61 7465 0a    temp......late.
  ```
- Add support for ng-template (angular.js template).
